### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/compression_test1.py
+++ b/compression_test1.py
@@ -7,13 +7,13 @@ import fileinput
 
 def test(data):
         u = len(data)/2
-        print "Uncompressed: %d" % (u)
+        print "Uncompressed: {0:d}".format((u))
 
         for i in range(1,10):
                 c = zlib.compress(data.decode('hex'),i)
                 b = bz2.compress(data.decode('hex'),i)
-                print "zlib compression level: %d, bytes: %d, ratio: %2.2f" % (i,len(c), 100-len(c)/(float(u))*100)
-                print "bz2  compression level: %d, bytes: %d, ratio: %2.2f" % (i,len(b), 100-len(b)/(float(u))*100)
+                print "zlib compression level: {0:d}, bytes: {1:d}, ratio: {2:2.2f}".format(i, len(c), 100-len(c)/(float(u))*100)
+                print "bz2  compression level: {0:d}, bytes: {1:d}, ratio: {2:2.2f}".format(i, len(b), 100-len(b)/(float(u))*100)
                                          
 
 for line in fileinput.input():

--- a/compression_test2.py
+++ b/compression_test2.py
@@ -21,16 +21,16 @@ def test(msg_data):
 
         print "Compressed data(hex): " + msg_data.encode('hex')
 
-        msg_data = struct.pack('>4si%ds' % len(msg_data)  ,zlib_magic,len(msg_data),msg_data)
+        msg_data = struct.pack('>4si{0:d}s'.format(len(msg_data))  ,zlib_magic,len(msg_data),msg_data)
         #msg_data = "ZLIB%s%s" % (ser_uint(len(msg_data)),msg_data)
 
         print "Packed data: " + msg_data.encode('hex')
 
         if msg_data[:4] == zlib_magic:
                 msg_len = deser_uint(msg_data[4:8])
-                print "msg_len: %s" % msg_len
+                print "msg_len: {0!s}".format(msg_len)
                 
-                a,b,c = struct.unpack('>4si%ds' % msg_len,msg_data)
+                a,b,c = struct.unpack('>4si{0:d}s'.format(msg_len),msg_data)
                 print "Pack:",a,b,c.encode('hex')
                 new_data = zlib.decompress(c)
                 print "Decompressed data: " + new_data


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:daedalus:misc?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:daedalus:misc?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
